### PR TITLE
Add whiteLabel for GIEX TV06 (_TZE200_py4cm3he)

### DIFF
--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5604,7 +5604,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Moes", "ZTRV-ZX-TV01-MS", "Thermostat radiator valve", ["_TZE200_7yoranx2"]),
             tuya.whitelabel("Moes", "TV01-ZB", "Thermostat radiator valve", ["_TZE200_e9ba97vf"]),
             tuya.whitelabel("AlecoAir", "HA-08_THERMO", "Thermostat radiator valve", ["_TZE200_wsbfwodu"]),
-            tuya.whitelabel("GIEX", "TV06", "Thermostat radiator valve", ["_TZE200_py4cm3he"])
+            tuya.whitelabel("GIEX", "TV06", "Thermostat radiator valve", ["_TZE200_py4cm3he"]),
         ],
         ota: true,
         fromZigbee: [tuya.fz.datapoints],

--- a/src/devices/tuya.ts
+++ b/src/devices/tuya.ts
@@ -5604,6 +5604,7 @@ export const definitions: DefinitionWithExtend[] = [
             tuya.whitelabel("Moes", "ZTRV-ZX-TV01-MS", "Thermostat radiator valve", ["_TZE200_7yoranx2"]),
             tuya.whitelabel("Moes", "TV01-ZB", "Thermostat radiator valve", ["_TZE200_e9ba97vf"]),
             tuya.whitelabel("AlecoAir", "HA-08_THERMO", "Thermostat radiator valve", ["_TZE200_wsbfwodu"]),
+            tuya.whitelabel("GIEX", "TV06", "Thermostat radiator valve", ["_TZE200_py4cm3he"])
         ],
         ota: true,
         fromZigbee: [tuya.fz.datapoints],


### PR DESCRIPTION
Hello
This pull request adds a whiteLabel entry for the GIEX TV06 Zigbee thermostat radiator valve (fingerprint _TZE200_py4cm3he).

Although the device is functionally identical to existing models, it features a new appearance and model number. 
Adding this whiteLabel entry allows Zigbee2MQTT frontend to display the correct image and model name, 
avoiding confusion for users and ensuring the device is recognized as supported.

Thank you!